### PR TITLE
NGC-2919 Remove unnecessary failing assertion

### DIFF
--- a/src/test/scala/uk/gov/hmrc/ngchelptosavecontract/mobilehelptosave/AccountSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ngchelptosavecontract/mobilehelptosave/AccountSpec.scala
@@ -73,10 +73,6 @@ class AccountSpec
           ((jsonBody \ "terms") (1) \ "endDate").as[String] should fullyMatch regex isoDateRegex
           ((jsonBody \ "terms") (1) \ "bonusEstimate").as[String] shouldBe "0.00"
         }
-
-        withClue(jsonBody \ "correlationId") {
-          jsonBody.as[JsObject].keys should not contain "correlationId"
-        }
       }
     }
 


### PR DESCRIPTION
NS&I auto generate a correlationId if we don't supply one, and this behaviour won't break us - all we depend on is them returning what we sent if we do supply one.